### PR TITLE
Fixed #59

### DIFF
--- a/AnimeNow/ProfileViewController.swift
+++ b/AnimeNow/ProfileViewController.swift
@@ -158,7 +158,7 @@ public class ProfileViewController: ThreadViewController {
             })
 
             let activeEndString = user.activeEnd.timeAgo()
-            let activeEndStringFormatted = activeEndString == "Just now" ? "active now" : "\(activeEndString) ago"
+            let activeEndStringFormatted = activeEndString == "Just now" ? "active now" : ("\(activeEndString)".isEmpty ? "" : "\(activeEndString) ago")
             self.activeAgo.text = user.active ? "active now" : activeEndStringFormatted
 
             if user.details.posts >= 1000 {

--- a/AnimeNow/ProfileViewController.swift
+++ b/AnimeNow/ProfileViewController.swift
@@ -157,8 +157,8 @@ public class ProfileViewController: ThreadViewController {
                 return attributedString
             })
 
-            let activeEndString = user.activeEnd.timeAgo()
-            let activeEndStringFormatted = activeEndString == "Just now" ? "active now" : ("\(activeEndString)".isEmpty ? "" : "\(activeEndString) ago")
+            let activeEndString = user.activeEnd.timeAgo()            
+            let activeEndStringFormatted = activeEndString == "Just now" ? "active now" : "\(activeEndString)" != "" ? "\(activeEndString) ago" : ""
             self.activeAgo.text = user.active ? "active now" : activeEndStringFormatted
 
             if user.details.posts >= 1000 {


### PR DESCRIPTION
Tiny little change for when there is no active end, merge/adjust main branch. This is my fault actually lol, I noticed this bug a while ago and forgot about it, any new users without an user.activeEnd.timeAgo() will just show "ago".

![simulator screen shot 13 feb 2016 05 51 01](https://cloud.githubusercontent.com/assets/7774083/13026153/03f27b6e-d216-11e5-9f82-1df9162da54f.png)



